### PR TITLE
add helpers for automation config

### DIFF
--- a/helpers/disable_smb_v1.py
+++ b/helpers/disable_smb_v1.py
@@ -1,0 +1,50 @@
+import sys
+from tqdm import tqdm
+import vm_config_parser
+
+WINDOWS_REQURED = "Win"
+DISABLE_SMB1_COMMAND = ['cmd.exe',
+                        '/k',
+                        '%windir%\System32\\reg.exe',
+                        'ADD',
+                        'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters',
+                        '/v',
+                        'SMB1',
+                        '/t',
+                        'REG_DWORD',
+                        '/d',
+                        '0',
+                        '/f']
+
+
+def main(argv):
+    snapshots_taken = 0
+    usage_statement = "disable_smb_v1.py <config.json> <VM_PREFIX>"
+    if len(argv) < 3:
+        print ("INCORRECT PARAMETER LIST:\n " + usage_statement)
+        exit(1)
+
+    config_file = argv[1]
+    prefix = argv[2]
+    vmServer = vm_config_parser.get_vm_server(config_file=config_file)
+    if vmServer is None:
+        print ("Failed to connect to VM environment")
+        exit(1)
+
+    vmServer.enumerateVms()
+    for vm in tqdm(vmServer.vmList):
+        if prefix in vm.vmName and WINDOWS_REQURED in vm.vmName:
+            # expand here to disable SMBv1
+            vm.powerOn()
+            vmServer.waitForVmsToBoot([vm])
+            vm.setUsername("vagrant")
+            vm.setPassword("vagrant")
+            vm.runCmdOnGuest(DISABLE_SMB1_COMMAND)
+            vm.powerOff()
+            vm.takeSnapshot("DisableSMBv1")
+            snapshots_taken += 1
+
+    print("Task Complete " + str(snapshots_taken) + " new 'DisableSMBv1' snapshots taken")
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/helpers/enable_uac.py
+++ b/helpers/enable_uac.py
@@ -1,0 +1,51 @@
+import sys
+import time
+from tqdm import tqdm
+import vm_config_parser
+
+WINDOWS_REQURED = "Win"
+UAC_ENABLE_COMMAND = ['cmd.exe',
+                      '/k',
+                      '%windir%\System32\\reg.exe',
+                      'ADD',
+                      'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
+                      '/v',
+                      'EnableLUA',
+                      '/t',
+                      'REG_DWORD',
+                      '/d',
+                      '1',
+                      '/f']
+
+
+def main(argv):
+    snapshots_taken = 0
+    usage_statement = "enable_uac.py <config.json> <VM_PREFIX>"
+    if len(argv) < 3:
+        print ("INCORRECT PARAMETER LIST:\n " + usage_statement)
+        exit(1)
+
+    config_file = argv[1]
+    prefix = argv[2]
+    vmServer = vm_config_parser.get_vm_server(config_file=config_file)
+    if vmServer is None:
+        print ("Failed to connect to VM environment")
+        exit(1)
+
+    vmServer.enumerateVms()
+    for vm in tqdm(vmServer.vmList):
+        if prefix in vm.vmName and WINDOWS_REQURED in vm.vmName:
+            vm.powerOn()
+            vmServer.waitForVmsToBoot([vm])
+            vm.setUsername('vagrant')
+            vm.setPassword('vagrant')
+            vm.scheduleCmdOnGuest(UAC_ENABLE_COMMAND, 1)
+            time.sleep(5 + 60)
+            vm.powerOff()
+            vm.takeSnapshot("EnableUAC")
+            snapshots_taken += 1
+
+    print("Task Complete " + str(snapshots_taken) + " new 'EnableUAC' snapshots taken")
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/helpers/remove_snapshot.py
+++ b/helpers/remove_snapshot.py
@@ -1,0 +1,27 @@
+import sys
+from tqdm import tqdm
+import vm_config_parser
+
+
+def main(argv):
+    usage_statement = "set_snapshot.py <config.json> <SNAPSHOT_NAME> <VM_PREFIX>"
+    if len(argv) < 3:
+        print ("INCORRECT PARAMETER LIST:\n " + usage_statement)
+        exit(1)
+
+    config_file = argv[1]
+    snapshot_name = argv[2]
+    prefix = argv[3]
+    vmServer = vm_config_parser.get_vm_server(config_file=config_file)
+    if vmServer is None:
+        print ("Failed to connect to VM environment")
+        exit(1)
+
+    vmServer.enumerateVms()
+    for vm in tqdm(vmServer.vmList):
+        if prefix in vm.vmName:
+            vm.powerOff()
+            vm.deleteSnapshot(snapshot_name)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/helpers/revert_snapshot.py
+++ b/helpers/revert_snapshot.py
@@ -1,0 +1,27 @@
+import sys
+from tqdm import tqdm
+import vm_config_parser
+
+
+def main(argv):
+    usage_statement = "revert_snapshot.py <config.json> <SNAPSHOT_NAME> <VM_PREFIX>"
+    if len(argv) < 3:
+        print ("INCORRECT PARAMETER LIST:\n " + usage_statement)
+        exit(1)
+
+    config_file = argv[1]
+    snapshot_name = argv[2]
+    prefix = argv[3]
+    vmServer = vm_config_parser.get_vm_server(config_file=config_file)
+    if vmServer is None:
+        print ("Failed to connect to VM environment")
+        exit(1)
+
+    vmServer.enumerateVms()
+    for vm in tqdm(vmServer.vmList):
+        if prefix in vm.vmName:
+            vm.powerOff()
+            vm.revertToSnapshotByName(snapshot_name)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/helpers/set_vm_network.py
+++ b/helpers/set_vm_network.py
@@ -1,0 +1,63 @@
+import sys
+from tqdm import tqdm
+from pyVmomi import vim
+import vm_config_parser
+
+
+def set_network(vm_server, vm, target_network):
+    nic = None
+    backing_network = None
+
+    # find the backing network requested
+    for network in vm_server.getObject(vim.Network):
+        if target_network == network.name:
+            backing_network = network
+            break
+
+    for device in vm.vmObject.config.hardware.device:
+        if isinstance(device, vim.vm.device.VirtualEthernetCard):
+            nic = vim.vm.device.VirtualDeviceSpec()
+            nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+            nic.device = device
+            nic.device.wakeOnLanEnabled = True
+
+            nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+            nic.device.backing.network = backing_network
+            nic.device.backing.deviceName = target_network
+            nic.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+            nic.device.connectable.startConnected = True
+            nic.device.connectable.allowGuestControl = True
+
+    if nic is not None:
+        config = vim.vm.ConfigSpec(deviceChange=[nic])
+        task = vm.vmObject.ReconfigVM_Task(config)
+        vm.waitForTask(task)
+
+
+def main(argv):
+    snapshots_taken = 0
+    usage_statement = "set_vm_network.py <config.json> <VM_PREFIX> <TARGET_NETWORK>"
+    if len(argv) < 4:
+        print ("INCORRECT PARAMETER LIST:\n " + usage_statement)
+        exit(1)
+
+    config_file = argv[1]
+    prefix = argv[3]
+    target_network = argv[2]
+    vm_server = vm_config_parser.get_vm_server(config_file=config_file)
+    if vm_server is None:
+        print ("Failed to connect to VM environment")
+        exit(1)
+
+    vm_server.enumerateVms()
+    for vm in tqdm(vm_server.vmList):
+        if prefix in vm.vmName:
+            # expand here to configure the network passed
+            set_network(vm_server, vm, target_network)
+            vm.takeSnapshot("TargetNetwork")
+            snapshots_taken += 1
+
+    print("Task Complete " + str(snapshots_taken) + " new 'TargetNetwork' snapshots taken")
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/helpers/take_snapshot.py
+++ b/helpers/take_snapshot.py
@@ -1,0 +1,27 @@
+import sys
+from tqdm import tqdm
+import vm_config_parser
+
+
+def main(argv):
+    usage_statement = "set_snapshot.py <config.json> <SNAPSHOT_NAME> <VM_PREFIX>"
+    if len(argv) < 3:
+        print ("INCORRECT PARAMETER LIST:\n " + usage_statement)
+        exit(1)
+
+    config_file = argv[1]
+    snapshot_name = argv[2]
+    prefix = argv[3]
+    vmServer = vm_config_parser.get_vm_server(config_file=config_file)
+    if vmServer is None:
+        print ("Failed to connect to VM environment")
+        exit(1)
+
+    vmServer.enumerateVms()
+    for vm in tqdm(vmServer.vmList):
+        if prefix in vm.vmName:
+            vm.powerOff()
+            vm.takeSnapshot(snapshot_name)
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/helpers/vm_config_parser.py
+++ b/helpers/vm_config_parser.py
@@ -1,0 +1,21 @@
+import json
+import os
+import vm_automation
+
+
+def get_vm_server(config_file):
+    if os.path.isfile(config_file):
+        with open(config_file) as config_file_handle:
+            config_map = json.load(config_file_handle)
+
+            if config_map['HYPERVISOR_TYPE'].lower() == "esxi":
+                vmServer = vm_automation.esxiServer(config_map["HYPERVISOR_HOST"],
+                                                    config_map["HYPERVISOR_USERNAME"],
+                                                    config_map["HYPERVISOR_PASSWORD"],
+                                                    config_map["HYPERVISOR_LISTENING_PORT"],
+                                                    'esxi_automation.log')
+                vmServer.connect()
+            if config_map['HYPERVISOR_TYPE'].lower() == "workstation":
+                vmServer = vm_automation.workstationServer(config_map, 'workstation_automation.log')
+        return vmServer
+    return None


### PR DESCRIPTION
These scripts provide some quick helpers for configuring groups of
virtual machines some basic tasks needed pior to automation execution.

All consume the same HYPERVISOR_CONFIG file as `autoPayloadTest.py` and
take basic command required parameters always ending with the prefix for
virtual machine catalog names for the task to apply to.