### PR TITLE
windows basic test for staged and stageless meterp

### DIFF
--- a/public_configs/sanity_check/Win_Meterpeter_Simple.json
+++ b/public_configs/sanity_check/Win_Meterpeter_Simple.json
@@ -1,0 +1,92 @@
+{
+	"HTTP_PORT":			5309,
+	"STARTING_LISTENER":		30000,
+	"CREDS_FILE":			"../JSON/creds.json",
+	"MSF_HOSTS":
+	[
+		{
+			"TYPE":			"VIRTUAL",
+			"METHOD":		"VM_TOOLS_UPLOAD",
+			"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
+			"CPE":			"cpe:/a:rapid7:metasploit:::",
+			"MSF_PATH":		"/home/msfuser/rapid7/metasploit-framework",
+			"MSF_ARTIFACT_PATH":	"/home/msfuser/rapid7/test_artifacts"
+		}
+	],
+	"TARGETS":
+	[
+		{
+			"CPE":			"cpe:/o:microsoft:windows_server_2016:::x64"
+		}
+	],
+	"TARGET_GLOBALS":
+	{
+			"TYPE":			"VIRTUAL",
+			"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
+			"METHOD":		"VM_TOOLS_UPLOAD",
+			"PAYLOAD_DIRECTORY":	"C:\\payload_test",
+			"PYTHON":		"C:\\tools\\python\\python.exe",
+			"METERPRETER_PYTHON":	"C:\\tools\\python\\python.exe",
+			"METERPRETER_JAVA":	"C:\\Program Files\\Java\\jre1.8.0_151\\java.exe"
+	},	
+	"PAYLOADS":
+	[
+		{
+			"NAME": "windows/x64/meterpreter/bind_tcp",
+			"SETTINGS": []
+		},
+		{
+			"NAME": "windows/meterpreter/reverse_tcp",
+			"SETTINGS": []
+		},
+		{
+			"NAME": "windows/x64/meterpreter_bind_tcp",
+			"SETTINGS": []
+		},
+		{
+			"NAME": "windows/meterpreter_reverse_tcp",
+			"SETTINGS": []
+		}
+	],
+	"MODULES":	
+	[
+		{
+			"NAME":		"exploit/multi/handler",
+			"SETTINGS":	[]
+		}
+	],
+	"COMMAND_LIST": [
+		"sessions -C sysinfo",
+		"sessions -C ifconfig",
+		"sessions -C sessions -l",
+		"sessions -C getuid",
+		"loadpath test/modules",
+		"use post/test/meterpreter",
+		"set verbose true",
+		"set addentropy true",
+		"set session 1",
+		"run",
+		"use post/test/railgun",
+		"set verbose true",
+		"set session 1",
+		"run"
+	],
+	"SUCCESS_LIST": [
+		"[+] should return a list of processes",
+		"[+] should return a user id",
+		"[+] should return a sysinfo Hash",
+		"[+] should return network interfaces",
+		"[+] should have an interface that matches session_host",
+		"[+] should return the proper directory separator",
+		"[+] should return the current working directory",
+		"[+] should list files in the current directory",
+		"[+] should stat a directory",
+		"[+] should create and remove a dir",
+		"[+] should change directories",
+		"[+] should create and remove files",
+		"[+] should upload a file",
+		"[+] should move files",
+		"[+] should copy files",
+		"[+] should do md5 and sha1 of files"
+	]
+}


### PR DESCRIPTION
To fulfill @bcook-r7 's request for a basic quick sanity test that can be run on every PR.

In my env this test takes 9 minutes to complete for all 4 payloads.

This job will migrate to the framework's `test/modules/payloads/` path once we are in a ready to support community contribution of tests.

This will execute using a single console VM and a single target VM to validate the basic meterpreter and railgun test modules pass.

A pull request based executor for this job will be added once merged here.  Eventually we can automate failure artifacts upload to a public location for community consumption.  For now we can post them as comments when a contributor needs them.