### PR TITLE
Fix when the stage two and three scripts are used

### DIFF
--- a/apt_shared.py
+++ b/apt_shared.py
@@ -1444,8 +1444,8 @@ def waitForMeterpreters(testConfig, sessionCounter, timeoutSec = 500):
     staticCount = 0
     finishedSpawning = False
     try:
-        for i in range(timeoutSec):
-            if finishedSpawning and staticCount > 5:
+        for i in range(timeoutSec/10):
+            if finishedSpawning and staticCount > 15:
                 break
             previousCount = currentCount
             currentCount = 0


### PR DESCRIPTION
There was a bug that got introduced on the refactor where stage two and three fired when not required.  The bright side was that error checking and handling prevented the mistakes from affecting the test outcomes, but it wasted time executing code that always failed and cluttered the logs with recovered errors that should never have happened to begin with.

This corrects those errors and only fires stage two and three scripts when they are needed.

Testing steps:
- [x] reverse_tcp upload
- [x] any payload exploit
- [x] bind_tcp upload