### PR TITLE
allow branches with a '/' path

### DIFF
--- a/apt_shared.py
+++ b/apt_shared.py
@@ -314,7 +314,7 @@ def generateBranchScript(branchString, logFile):
             logMsg(logFile, "NONSTANDARD FRAMEWORK USERNAME: " + userName)
             repoName = branchData[1]
             logMsg(logFile, "NONSTANDARD FRAMEWORK REPO NAME: " + repoName)
-            branchName = branchData[2]
+            branchName = '/'.join(branchData[2:])
             logMsg(logFile, "NONSTANDARD FRAMEWORK BRANCH NAME: " + branchName)
             gitSyntax = "https://github.com/" + userName + "/" + repoName + ".git"
             gitScript = gitScript + "git remote add " + userName + " " + gitSyntax + "\n"


### PR DESCRIPTION
When parsing a branch name `/` is a valid value, update here allows for something like `wvu-r7/metasploit-framework/pr/9618`.
