### PR TITLE
Fix indention to allow AUX modules again

### DIFF
--- a/apt_shared.py
+++ b/apt_shared.py
@@ -252,8 +252,8 @@ def checkStagesNeeded(targetData):
         for sessionData in targetData['SESSION_DATASETS']:
             if 'PAYLOAD' in sessionData:
                 stageTwoNeeded = True
-            if 'bind' in sessionData['PAYLOAD']['NAME']:
-                stageThreeNeeded = True
+                if 'bind' in sessionData['PAYLOAD']['NAME']:
+                    stageThreeNeeded = True
     return (stageTwoNeeded, stageThreeNeeded)
 
 


### PR DESCRIPTION
I dorked up a conditional on a recent clean-up and it made modules without payloads (AUX) fail.  This returns the functionality.

- [ ] Run a test that uses an AUX module without a payload.

Module/Command/Success json info:
```
	"MODULES":	
	[
		{
			"NAME":		"auxiliary/scanner/smb/smb1",
			"SETTINGS":	
				["verbose=true"]
		}
	],
	"COMMAND_LIST":
	[],
	"SUCCESS_LIST": [
		"supports SMBv1 dialect"
	]
```