### PR TITLE
Add failure check

### DIFF
--- a/apt_shared.py
+++ b/apt_shared.py
@@ -97,7 +97,7 @@ def checkData(testConfig):
                         statusFlag = False
             if 'FAILURE_LIST' in target:
                 for item in target['FAILURE_LIST']:
-                    for line in fileContents.split():
+                    for line in fileContents.splitlines():
                         if item in line:
                             logMsg(testConfig['LOG_FILE'], str(line))
                             statusFlag = False

--- a/apt_shared.py
+++ b/apt_shared.py
@@ -90,10 +90,16 @@ def checkData(testConfig):
             except IOError as e:
                 logMsg(testConfig['LOG_FILE'], "FAILED TO OPEN LOCAL REPORT FILE: " + sessionData['LOCAL_SESSION_FILE'])
                 continue
-            for item in target['SUCCESS_LIST']:
-                if item not in fileContents:
-                    logMsg(testConfig['LOG_FILE'], str(item))
-                    statusFlag = False
+            if 'SUCCESS_LIST' in target:
+                for item in target['SUCCESS_LIST']:
+                    if item not in fileContents:
+                        logMsg(testConfig['LOG_FILE'], str(item))
+                        statusFlag = False
+            if 'FAILURE_LIST' in target:
+                for item in target['FAILURE_LIST']:
+                    if item in fileContents:
+                        logMsg(testConfig['LOG_FILE'], str(item))
+                        statusFlag = False
             sessionData['STATUS'] = statusFlag
             if statusFlag:
                 logMsg(testConfig['LOG_FILE'], sessionData['LOCAL_SESSION_FILE'])
@@ -1385,7 +1391,6 @@ def verifyConfig(jsonDic):
     requiredList.append("STARTING_LISTENER")
     requiredList.append("MSF_HOSTS")
     requiredList.append("TARGETS")
-    requiredList.append("SUCCESS_LIST")
     for item in requiredList:
         if item not in jsonDic:
             print("MISSING " + item + " IN CONFIGURATION FILE\n")

--- a/apt_shared.py
+++ b/apt_shared.py
@@ -97,9 +97,10 @@ def checkData(testConfig):
                         statusFlag = False
             if 'FAILURE_LIST' in target:
                 for item in target['FAILURE_LIST']:
-                    if item in fileContents:
-                        logMsg(testConfig['LOG_FILE'], str(item))
-                        statusFlag = False
+                    for line in fileContents.split():
+                        if item in line:
+                            logMsg(testConfig['LOG_FILE'], str(line))
+                            statusFlag = False
             sessionData['STATUS'] = statusFlag
             if statusFlag:
                 logMsg(testConfig['LOG_FILE'], sessionData['LOCAL_SESSION_FILE'])

--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -75,6 +75,7 @@ def main():
     """
     apt_shared.expandGlobalList(configData['TARGETS'], configData['COMMAND_LIST'], "COMMAND_LIST")
     apt_shared.expandGlobalList(configData['TARGETS'], configData['SUCCESS_LIST'], "SUCCESS_LIST")
+    apt_shared.expandGlobalList(configData['TARGETS'], configData['FAILURE_LIST'], "FAILURE_LIST")
             
     
     # DEBUG PRINT


### PR DESCRIPTION
Previously, we only checked for the presence of a string to determine success in a test run.  This adds a new section of the test config that checks for the presence of a string to denote failure.  This is especially useful in the case of built-in Tests that produce standardized error messages like: `[-] FAILED: $failure`
Testing:
- [ ] Add a `FAILURE_LIST` entry to the json test file and populate it with the word "FAILED"
- [ ] Add a test you know will fail- like Railgun to a Linux host
- [ ] run
- [ ] verify that not only does the test fail as expected, the failure cause is documented in the log file.
