### PR TITLE
Make sure we do not try to expand things that are not there...

### DIFF
--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -74,8 +74,10 @@ def main():
     EXPAND COMMAND_LIST AND SUCCESS_LIST TO ALL TARGETS
     """
     apt_shared.expandGlobalList(configData['TARGETS'], configData['COMMAND_LIST'], "COMMAND_LIST")
-    apt_shared.expandGlobalList(configData['TARGETS'], configData['SUCCESS_LIST'], "SUCCESS_LIST")
-    apt_shared.expandGlobalList(configData['TARGETS'], configData['FAILURE_LIST'], "FAILURE_LIST")
+    if 'SUCCESS_LIST' in configData:
+        apt_shared.expandGlobalList(configData['TARGETS'], configData['SUCCESS_LIST'], "SUCCESS_LIST")
+    if 'FAILURE_LIST' in configData:
+        apt_shared.expandGlobalList(configData['TARGETS'], configData['FAILURE_LIST'], "FAILURE_LIST")
             
     
     # DEBUG PRINT


### PR DESCRIPTION
https://github.com/rapid7/geppetto/pull/41 will crash when someone feeds a config file without a `FAILURE_LIST` and a `SUCCESS_LIST`.  That breaks all previous config files.

This PR prevents the error.
