### PR TITLE
Add skip snapshot

### DIFF
--- a/apt_shared.py
+++ b/apt_shared.py
@@ -833,7 +833,7 @@ def prepConfig(args):
         configData['TARGETS'] = newTargets
     if args.skipSnapshotting:
         configData['SKIP_SNAPSHOTTING'] = "true"
-    else:
+    if 'SKIP_SNAPSHOTTING' not in configData:
         configData['SKIP_SNAPSHOTTING'] = "false"
     if args.framework != None:
         configData['FRAMEWORK_BRANCH'] = args.framework

--- a/apt_shared.py
+++ b/apt_shared.py
@@ -832,9 +832,9 @@ def prepConfig(args):
         newTargets.append(mergedTarget)
         configData['TARGETS'] = newTargets
     if args.skipSnapshotting:
-        configData['SKIP_SNAPSHOTTING'] = "true"
+        configData['SKIP_SNAPSHOTTING'] = True
     if 'SKIP_SNAPSHOTTING' not in configData:
-        configData['SKIP_SNAPSHOTTING'] = "false"
+        configData['SKIP_SNAPSHOTTING'] = False
     if args.framework != None:
         configData['FRAMEWORK_BRANCH'] = args.framework
     if args.payload != None:
@@ -1056,7 +1056,7 @@ def prepTestVms(testConfig):
     testVms = []
     for host in testConfig['TARGETS'] + testConfig['MSF_HOSTS']:
         if host['TYPE'] == "VIRTUAL":
-            if 'SKIP_SNAPSHOTTING' not in testConfig or testConfig['SKIP_SNAPSHOTTING'].upper() == "FALSE":
+            if 'SKIP_SNAPSHOTTING' not in testConfig or testConfig['SKIP_SNAPSHOTTING'] == False:
                 host['TEMP_SNAPSHOT'] = 'PAYLOAD_TESTING_'+testConfig['TIMESTAMP']
                 if not host['VM_OBJECT'].takeSnapshot(host['TEMP_SNAPSHOT']):
                     logMsg(testConfig['LOG_FILE'], "FAILED TO CREATE SNAPSHOT ON " + host['NAME'])

--- a/apt_shared.py
+++ b/apt_shared.py
@@ -831,6 +831,10 @@ def prepConfig(args):
         mergedTarget.update(targetOverride)
         newTargets.append(mergedTarget)
         configData['TARGETS'] = newTargets
+    if args.skipSnapshotting:
+        configData['SKIP_SNAPSHOTTING'] = "true"
+    else:
+        configData['SKIP_SNAPSHOTTING'] = "false"
     if args.framework != None:
         configData['FRAMEWORK_BRANCH'] = args.framework
     if args.payload != None:
@@ -1052,9 +1056,10 @@ def prepTestVms(testConfig):
     testVms = []
     for host in testConfig['TARGETS'] + testConfig['MSF_HOSTS']:
         if host['TYPE'] == "VIRTUAL":
-            host['TEMP_SNAPSHOT'] = 'PAYLOAD_TESTING_'+testConfig['TIMESTAMP']
-            if not host['VM_OBJECT'].takeSnapshot(host['TEMP_SNAPSHOT']):
-                logMsg(testConfig['LOG_FILE'], "FAILED TO CREATE SNAPSHOT ON " + host['NAME'])
+            if 'SKIP_SNAPSHOTTING' not in testConfig or testConfig['SKIP_SNAPSHOTTING'].upper() == "FALSE":
+                host['TEMP_SNAPSHOT'] = 'PAYLOAD_TESTING_'+testConfig['TIMESTAMP']
+                if not host['VM_OBJECT'].takeSnapshot(host['TEMP_SNAPSHOT']):
+                    logMsg(testConfig['LOG_FILE'], "FAILED TO CREATE SNAPSHOT ON " + host['NAME'])
             if 'TESTING_SNAPSHOT' in host:
                 logMsg(testConfig['LOG_FILE'], "TRYING TO REVERT " + host['NAME'] + " TO " + host['TESTING_SNAPSHOT'])
                 host['VM_OBJECT'].revertToSnapshotByName(host['TESTING_SNAPSHOT'])

--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -103,7 +103,7 @@ def main():
     if 'SKIP_SNAPSHOTTING' in configData:
         apt_shared.logMsg(configData['LOG_FILE'], "SKIP_SNAPSHOTTING IN configData")
         apt_shared.logMsg(configData['LOG_FILE'], "configData['SKIP_SNAPSHOTTING'] = " + str(configData['SKIP_SNAPSHOTTING']))
-    if 'SKIP_SNAPSHOTTING' in configData and configData['SKIP_SNAPSHOTTING'].upper() != "TRUE":
+    if 'SKIP_SNAPSHOTTING' in configData and configData['SKIP_SNAPSHOTTING'] == False:
         if apt_shared.resetVms(configData):
             apt_shared.logMsg(configData['LOG_FILE'], "SUCCESSFULLY RESET VMS")
         else:

--- a/autoPayloadTest.py
+++ b/autoPayloadTest.py
@@ -11,9 +11,10 @@ def main():
     parser.add_argument("-vf", "--verboseFilename", help="Echo report filename to console", action="store_true")
     parser.add_argument("-f", "--framework", help="Framework branch to use (Overrides testfile)")
     parser.add_argument("-m", "--module", help="Module to use")
-    parser.add_argument("-t", "--targetName", help="Target CPE/OS/NAME to use (Overrides testfile)")
     parser.add_argument("-p", "--payload", help="Meterpreter payload to use")
     parser.add_argument("-po", "--payloadOptions", help="Comma delineated venom-style settings for the given payload: attribute=x,attribute2=y...")
+    parser.add_argument("-ss", "--skipSnapshotting", help="Skip intial snapshot and restore (trashes current VM state and leaves VMs on)", action="store_true")
+    parser.add_argument("-t", "--targetName", help="Target CPE/OS/NAME to use (Overrides testfile)")
     parser.add_argument("testfile", help="json test file to use")
     args = parser.parse_args()
 
@@ -99,10 +100,14 @@ def main():
     """
     RETURN VMS TO SNAPSHOTS
     """
-    if apt_shared.resetVms(configData):
-        apt_shared.logMsg(configData['LOG_FILE'], "SUCCESSFULLY RESET VMS")
-    else:
-        apt_shared.logMsg(configData['LOG_FILE'], "THERE WAS A PROBLEM RESETTING VMS")
+    if 'SKIP_SNAPSHOTTING' in configData:
+        apt_shared.logMsg(configData['LOG_FILE'], "SKIP_SNAPSHOTTING IN configData")
+        apt_shared.logMsg(configData['LOG_FILE'], "configData['SKIP_SNAPSHOTTING'] = " + str(configData['SKIP_SNAPSHOTTING']))
+    if 'SKIP_SNAPSHOTTING' in configData and configData['SKIP_SNAPSHOTTING'].upper() != "TRUE":
+        if apt_shared.resetVms(configData):
+            apt_shared.logMsg(configData['LOG_FILE'], "SUCCESSFULLY RESET VMS")
+        else:
+            apt_shared.logMsg(configData['LOG_FILE'], "THERE WAS A PROBLEM RESETTING VMS")
     
     """
     WAIT A COUPLE SECONDS TO MAKE SURE WVERYTHING COMPLETES, THEN RETURN THE PROPER VALUE


### PR DESCRIPTION
I've been thinking about how to speed up the nightly tests and realized a super simple way was to skip the snapshotting process.  Originally, I pictured that the VM state should be preserved so the VMs were returned to the original state.  It turns out that's not really important in most cases, and on multi-system tests, the snapshotting process takes as much time as the actual testing process because we can't parallelize the snapshotting.  

#Test process
- [ ] Run a normal test, verify that the VM is returned to the original state
- [ ] Run a test using the `-ss` flag at the command line or `SKIP_SNAPSHOTTING` set to the string "true" on the top-level of a json file and verify the VM is left in the running state.

cough, cough @jmartin-r7 