### PR TITLE
Linux tests

### DIFF
--- a/public_configs/sanity_check/Lin_Meterpreter_Simple.json
+++ b/public_configs/sanity_check/Lin_Meterpreter_Simple.json
@@ -16,13 +16,13 @@
 	"TARGETS":
 	[
 		{
+			"CPE":			"cpe:/o:fedoraproject:fedora:29::"
+		},
+		{
+			"CPE":			"cpe:/o:centos:centos:6::"
+		},
+		{
 			"CPE":			"cpe:/o:canonical:ubuntu_linux:16.04::"
-		},
-		{
-			"CPE":      "cpe:/o:fedoraproject:fedora:29::"
-		},
-		{
-			"CPE":			"cpe:/o:centos:centos:7::"
 		}
 	],
 	"TARGET_GLOBALS":
@@ -38,11 +38,11 @@
 	"PAYLOADS":
 	[
 		{
-			"NAME": "linux/x64/meterpreter_reverse_https",
+			"NAME": "linux/x64/meterpreter_reverse_tcp",
 			"SETTINGS": []
 		},
 		{
-			"NAME": "linux/x64/meterpreter_reverse_tcp",
+			"NAME": "linux/x64/meterpreter_reverse_https",
 			"SETTINGS": []
 		}
 	],

--- a/public_configs/sanity_check/Lin_Meterpreter_Simple.json
+++ b/public_configs/sanity_check/Lin_Meterpreter_Simple.json
@@ -1,0 +1,86 @@
+{
+	"HTTP_PORT":			5309,
+	"STARTING_LISTENER":		30000,
+	"CREDS_FILE":			"../JSON/creds.json",
+	"MSF_HOSTS":
+	[
+		{
+			"TYPE":			"VIRTUAL",
+			"METHOD":		"VM_TOOLS_UPLOAD",
+			"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
+			"CPE":			"cpe:/a:rapid7:metasploit:::",
+			"MSF_PATH":		"/home/msfuser/rapid7/metasploit-framework",
+			"MSF_ARTIFACT_PATH":	"/home/msfuser/rapid7/test_artifacts"
+		}
+	],
+	"TARGETS":
+	[
+		{
+			"CPE":			"cpe:/o:canonical:ubuntu_linux:16.04::"
+		},
+		{
+			"CPE":      "cpe:/o:fedoraproject:fedora:29::"
+		},
+		{
+			"CPE":			"cpe:/o:centos:centos:7::"
+		}
+	],
+	"TARGET_GLOBALS":
+	{
+		"TYPE":			"VIRTUAL",
+		"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
+		"METHOD":		"VM_TOOLS_UPLOAD",
+		"PAYLOAD_DIRECTORY":	"/home/vagrant/payload_test",
+		"PYTHON":		"/home/vagrant/bin/python",
+		"METERPRETER_PYTHON":	"/home/vagrant/bin/python",
+		"METERPRETER_JAVA":	"/home/vagrant/bin/java"
+	},
+	"PAYLOADS":
+	[
+		{
+			"NAME": "linux/x64/meterpreter_reverse_https",
+			"SETTINGS": []
+		},
+		{
+			"NAME": "linux/x64/meterpreter_reverse_tcp",
+			"SETTINGS": []
+		}
+	],
+	"MODULES":
+	[
+		{
+			"NAME":		"exploit/multi/handler",
+			"SETTINGS":	[]
+		}
+	],
+	"COMMAND_LIST": [
+		"sessions -C sysinfo",
+		"sessions -C ifconfig",
+		"sessions -C sessions -l",
+		"sessions -C getuid",
+		"loadpath test/modules",
+		"use post/test/meterpreter",
+		"set verbose true",
+		"set addentropy true",
+		"set session 1",
+		"run"
+	],
+	"SUCCESS_LIST": [
+		"[+] should return a list of processes",
+		"[+] should return a user id",
+		"[+] should return a sysinfo Hash",
+		"[+] should return network interfaces",
+		"[+] should have an interface that matches session_host",
+		"[+] should return the proper directory separator",
+		"[+] should return the current working directory",
+		"[+] should list files in the current directory",
+		"[+] should stat a directory",
+		"[+] should create and remove a dir",
+		"[+] should change directories",
+		"[+] should create and remove files",
+		"[+] should upload a file",
+		"[+] should move files",
+		"[+] should copy files",
+		"[+] should do md5 and sha1 of files"
+	]
+}


### PR DESCRIPTION
Simple Linux sanity test.
Runs meterpreter reverse tcp and meterpreter reverse https against Ubuntu 16.04, Fedora 29, and Centos 6. 