### PR TITLE
Expand nightly targets for all existing Windows

### DIFF
--- a/public_configs/nightly_tests/Win_10x64_autologin_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_10x64_autologin_meterpreter_nightly.json
@@ -18,6 +18,24 @@
 	[
 		{
 			"CPE": "cpe:/o:microsoft:windows_10:::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1511::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1607::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1703::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1709::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1803::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1809::x64"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_10x64_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_10x64_meterpreter_nightly.json
@@ -18,6 +18,24 @@
 	[
 		{
 			"CPE": "cpe:/o:microsoft:windows_10:::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1511::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1607::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1703::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1709::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1803::x64"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1809::x64"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_10x86_autologin_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_10x86_autologin_meterpreter_nightly.json
@@ -18,6 +18,24 @@
 	[
 		{
 			"CPE": "cpe:/o:microsoft:windows_10:::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1511::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1607::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1703::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1709::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1803::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1809::x86"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_10x86_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_10x86_meterpreter_nightly.json
@@ -18,6 +18,24 @@
 	[
 		{
 			"CPE": "cpe:/o:microsoft:windows_10:::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1511::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1607::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1703::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1709::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1803::x86"
+		},
+		{
+			"CPE": "cpe:/o:microsoft:windows_10:1809::x86"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_7x64_8x64_autologin_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_7x64_8x64_autologin_meterpreter_nightly.json
@@ -20,7 +20,16 @@
 			"CPE": "cpe:/o:microsoft:windows_7:::x64"
 		},
 		{
+			"CPE": "cpe:/o:microsoft:windows_7::sp1:x64"
+		},
+		{
 			"CPE": "cpe:/o:microsoft:windows_8:::x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1:::x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1::sp1:x64"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_7x64_8x64_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_7x64_8x64_meterpreter_nightly.json
@@ -20,7 +20,16 @@
 			"CPE": "cpe:/o:microsoft:windows_7:::x64"
 		},
 		{
+			"CPE": "cpe:/o:microsoft:windows_7::sp1:x64"
+		},
+		{
 			"CPE": "cpe:/o:microsoft:windows_8:::x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1:::x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1::sp1:x64"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_7x86_8x86_autologin_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_7x86_8x86_autologin_meterpreter_nightly.json
@@ -20,7 +20,16 @@
 			"CPE": "cpe:/o:microsoft:windows_7:::x86"
 		},
 		{
+			"CPE": "cpe:/o:microsoft:windows_7::sp1:x86"
+		},
+		{
 			"CPE": "cpe:/o:microsoft:windows_8:::x86"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1:::x86"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1::sp1:x86"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_7x86_8x86_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_7x86_8x86_meterpreter_nightly.json
@@ -20,7 +20,16 @@
 			"CPE": "cpe:/o:microsoft:windows_7:::x86"
 		},
 		{
+			"CPE": "cpe:/o:microsoft:windows_7::sp1:x86"
+		},
+		{
 			"CPE": "cpe:/o:microsoft:windows_8:::x86"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1:::x86"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_8.1::sp1:x86"
 		}
 	],
 	"TARGET_GLOBALS":

--- a/public_configs/nightly_tests/Win_server_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/Win_server_meterpreter_nightly.json
@@ -17,13 +17,25 @@
 	"TARGETS":
 	[
 		{
-			"CPE": "cpe:/o:microsoft:windows_server_2008::r2:x64"
+		    "CPE": "cpe:/o:microsoft:windows_server_2008::r2:x64"
 		},
 		{
-			"CPE": "cpe:/o:microsoft:windows_server_2012:::x64"
+		    "CPE": "cpe:/o:microsoft:windows_server_2008:r2:sp1:x64"
 		},
 		{
-			"CPE": "cpe:/o:microsoft:windows_server_2019:::x64"
+		    "CPE": "cpe:/o:microsoft:windows_server_2012::r2:x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_server_2012:r2:sp1:x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_server_2012:::x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_server_2016:::x64"
+		},
+		{
+		    "CPE": "cpe:/o:microsoft:windows_server_2019:::x64"
 		}
 	],
 	"TARGET_GLOBALS":


### PR DESCRIPTION
updates all new nightly configs to explicitly reference supported systems build with https://github.com/rapid7/metasploit-baseline-builder
