### PR TITLE
Update test file to reflect that we don't run a test, anymore.

### DIFF
--- a/public_configs/nightly_tests/NixVM_meterpreter_nightly.json
+++ b/public_configs/nightly_tests/NixVM_meterpreter_nightly.json
@@ -115,11 +115,8 @@
 		"[+] should copy files",
 		"[+] should do md5 and sha1 of files",
 		"[+] should return the result of echo",
-		"[+] should return the result after sleeping",
 		"[+] should return the full response after sleeping",
 		"[+] should return the result of echo 10 times",
-		"[*] Finished cmd_exec tests",
-		"[*] Starting cmd_exec quote tests",
 		"[+] should return the result of echo with single quotes",
 		"[+] should return the result of echo with double quotes"
 	]


### PR DESCRIPTION
Run tests and verify that cmd_exec tests pass on at least some linux targets.

Previously, the output for once of the tests was returned as success, even if the test did not run.  When we set these tests up, we did not know it, so I added it as a success artifact.  Turns out it did not run but reported success.  On a recent PR fixing the cmd_exec tests behavior (https://github.com/rapid7/metasploit-framework/pull/12463), I changed the test to only print out the success message if the test ran...  That broke the linux cmd_exec test check, because we assumed the test ran....

This removes the success artifact for that test in the Linux environment where it does not run, and it  some informational messages that should not have been success artifacts.